### PR TITLE
Add APort integrations to LLM security projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@
 | Decepticon : Vibe Hacking Agent                              | 基于自主多智能体红队测试服务，利用 AI agents在攻击者自动化它们之前自动化红队测试 | [Decepticon](https://github.com/PurpleAILAB/Decepticon)      |
 | Awesome_GPT_Super_PromptingChatGPT                           | 越狱提示词、GPT 智能体提示词、提示词注入及保护。ChatGPT越狱、GPT助理提示泄漏、LLM提示安全性、超级Prompt、黑客Prompt、安全Prompt | [Awesome_GPT_Super_Prompting](https://github.com/CyberAlbSecOP/Awesome_GPT_Super_Prompting) |
 | Agentic Security                                             | 开源 AgenticLLM漏洞扫描器（安全扫描工具）。可定制的规则集或基于代理的攻击，全面的模糊测试适用于任何LLMs。 | [Agentic Security](https://github.com/msoedov/agentic_security) |
+| APort Integrations                                           | 面向 AI Agent 工具调用的身份验证和策略执行中间件，在执行外部工具、副作用操作或 MCP/框架集成前增加确定性的授权检查。 | [APort Integrations](https://github.com/aporthq/aport-integrations) |
 | SecureBERT: CyberSecurity Language Model                     | 专门为网络安全任务量身定制的专用语言模型。该存储库记录了 SecureBERT 在使用操作码序列对恶意软件样本进行分类方面的研究、开发和实施。 | [SecureBert_Malware-Classification](https://github.com/kaushik-42/SecureBert_Malware-Classification) |
 | SecureBERT-NER                                               | 该模型用于从安全咨询文本中提取命名实体。专门针对网络安全文本进行训练的命名实体识别 (NER) 模型。它可以识别身份、安全团队、工具、时间、攻击等各种实体。 | [cybersecurity-ner](https://github.com/PriyankaMohan94/cybersecurity-ner) |
 | Luwak TTP Extractor                                          | 使用预训练模型从非结构化威胁报告中提取战术、技术和攻击过程 (TTP)。 它使用 [ERNIE](https://github.com/PaddlePaddle/ERNIE) 预训练模型从威胁报告中推断出常见的 TTP。 | [Luwak TTP Extractor](https://github.com/Qihoo360/Luwak/tree/master) |


### PR DESCRIPTION
## Summary
- Adds APort Integrations to the project list near other LLM/agent security tooling.
- Describes the specific security use case: deterministic identity and policy checks before agent tool calls or MCP/framework integrations perform side effects.

## Verification
- `git diff --check`
- Checked https://github.com/aporthq/aport-integrations returns HTTP 200.

Related bounty: https://github.com/aporthq/aport-integrations/issues/19

Payment: PayPal https://paypal.me/Jeremytsangchina; USDT TRC20 TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y